### PR TITLE
[3.3.1] Migrate OG generator to Route Handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2023-04-06
+
+### Changed
+
+- Migrated the OG generator from `/pages/api/og.tsx` to a route handler at `/app/api/og/route.tsx`
+  - This is a non-breaking change from the perspective of using the API, but if you've already modified your OG generator to customize the styles or content, you'll want to make those changes in the route handler now
+
 ## [3.3.0] - 2023-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,6 +133,6 @@ The template is built to be responsive, beautiful, and accessible right out of t
 
 If you really want to go deep on customization, you can create your own themes in the `src/tokens` folder to add custom accent and neutral palettes. You also have full control of the Tailwind configuration in the root folder `tailwind.config.js` file.
 
-We use [Vercel OG Image Generation](https://vercel.com/docs/concepts/functions/edge-functions/og-image-generation) to generate dynamic Open Graph (Facebook/Twitter) share images. You can edit the layout, styles, and text of OG Image using Tailwind classes in `src/pages/api/og.tsx`.
+We use [Vercel OG Image Generation](https://vercel.com/docs/concepts/functions/edge-functions/og-image-generation) in a [Route Handler](https://beta.nextjs.org/docs/routing/route-handlers) to generate dynamic Open Graph (Facebook/Twitter) share images. You can edit the layout, styles, and text of OG Image using Tailwind classes in `src/app/api/og/route.tsx`.
 
 This dynamic share image will use your custom `accentColor` setting, as well as data from the CMS.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-resume-generator",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Colin Hemphill",
     "email": "colin@colinhemphill.com",

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,23 +1,21 @@
 import * as colors from '@radix-ui/colors';
 import { ImageResponse } from '@vercel/og';
 import { NextRequest } from 'next/server';
-import resumeConfig from '../../../edit-me/config/resumeConfig';
+import resumeConfig from '../../../../edit-me/config/resumeConfig';
 
 const configAccent = resumeConfig.accentColor;
 const configNeutral = resumeConfig.neutralColor;
 
 const albertSansBold = fetch(
-  new URL('../../../public/fonts/AlbertSans-Bold.ttf', import.meta.url),
+  new URL('../../../../public/fonts/AlbertSans-Bold.ttf', import.meta.url),
 ).then((res) => res.arrayBuffer());
 const albertSansRegular = fetch(
-  new URL('../../../public/fonts/AlbertSans-Regular.ttf', import.meta.url),
+  new URL('../../../../public/fonts/AlbertSans-Regular.ttf', import.meta.url),
 ).then((res) => res.arrayBuffer());
 
-export const config = {
-  runtime: 'edge',
-};
+export const runtime = 'edge';
 
-const handler = async (req: NextRequest) => {
+export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const theme = searchParams.get('theme') || 'light';
@@ -99,6 +97,4 @@ const handler = async (req: NextRequest) => {
       status: 500,
     });
   }
-};
-
-export default handler;
+}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -18,7 +18,7 @@ export const runtime = 'edge';
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const theme = searchParams.get('theme') || 'light';
+    const theme = searchParams.get('theme') || resumeConfig.ogImageTheme;
     const name = searchParams.get('name');
     const fontBold = await albertSansBold;
     const fontRegular = await albertSansRegular;


### PR DESCRIPTION
Resolves #218

## [3.3.1] - 2023-04-06

### Changed

- Migrated the OG generator from `/pages/api/og.tsx` to a route handler at `/app/api/og/route.tsx`
  - This is a non-breaking change from the perspective of using the API, but if you've already modified your OG generator to customize the styles or content, you'll want to make those changes in the route handler now