### PR TITLE
[3.5.0] Add pdfTheme and appTheme to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2023-04-07
+
+### Added
+
+- `resumeConfig.appTheme` property
+  - If set to `ThemeSetting.System`, Tailwind will use `media` mode to set the color theme
+  - If set to `ThemeSetting.Light` or `ThemeSetting.Dark`, Tailwind will use the `class` mode to set the color scheme
+  - The app layout applies the `dark` class if `resumeConfig.appTheme` is set to `ThemeSetting.Dark`
+- `resumeConfig.pdfTheme` property
+  - Will set the color theme only for a generated PDF
+  - Can be set independently of the app theme
+  - Defaults to `Theme.Light` for printing purposes
+
+### Changed
+
+- All PDF icons use the color helper functions
+
 ## [3.4.0] - 2023-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Open the project in favorite editor, and open up the `edit-me/config/` folder at
 
 - `accentColor`: `AccentColor`. The name of an accent palette from [Radix UI Colors](https://www.radix-ui.com/docs/colors/palette-composition/the-scales#colors). If using a standard color, the contrasting text color will be white, and if using a bright color, the contrasting text color will be black.
 - `neutralColor`: `NeutralColor`. The name of a neutral palette from [Radix UI Grays](https://www.radix-ui.com/docs/colors/palette-composition/the-scales#grays).
-- `imageTheme`: `'light' | 'dark'`. Your OG share image and icons will generate either a light or a dark variant.
+- `appTheme`: `'system' | 'light' | 'dark'`. If `appTheme` is set to `system`, the résumé site will default to the user's system preference. If set to `light` or `dark` the user's preference will be overriden.
+- `imageTheme`: `'light' | 'dark'`. Your OG share image and app icons will be generated in either a light or a dark variant.
+- `pdfTheme`: `'light' | 'dark'`. Your PDF will be generated in either a light or a dark variant.
 
 ### Color Palette Examples
 

--- a/edit-me/config/Config.ts
+++ b/edit-me/config/Config.ts
@@ -40,8 +40,16 @@ export enum Theme {
   Light = 'light',
 }
 
+export enum ThemeSetting {
+  Dark = 'dark',
+  Light = 'light',
+  System = 'system',
+}
+
 export interface ResumeConfig {
   accentColor: AccentColorsBasic | AccentColorsBright;
   neutralColor: NeutralColors;
   imageTheme: Theme;
+  pdfTheme: Theme;
+  appTheme: ThemeSetting;
 }

--- a/edit-me/config/resumeConfig.ts
+++ b/edit-me/config/resumeConfig.ts
@@ -1,9 +1,17 @@
-import { AccentColors, NeutralColors, ResumeConfig, Theme } from './Config';
+import {
+  AccentColors,
+  NeutralColors,
+  ResumeConfig,
+  Theme,
+  ThemeSetting,
+} from './Config';
 
 const config: ResumeConfig = {
   accentColor: AccentColors.Blue,
   neutralColor: NeutralColors.Mauve,
+  appTheme: ThemeSetting.Dark,
   imageTheme: Theme.Light,
+  pdfTheme: Theme.Light,
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-resume-generator",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": {
     "name": "Colin Hemphill",
     "email": "colin@colinhemphill.com",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ config.autoAddCss = false;
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import clsx from 'clsx';
 import { headers } from 'next/headers';
+import { ThemeSetting } from '../../edit-me/config/Config';
 import './globals.css';
 
 const albert = Albert_Sans({
@@ -81,7 +82,14 @@ export const generateMetadata = async (): Promise<Metadata> => {
 // @ts-expect-error Server Component
 const RootLayout: React.FC<PropsWithChildren> = async ({ children }) => {
   return (
-    <html lang="en" className={clsx(albert.variable, jetBrainsMono.variable)}>
+    <html
+      lang="en"
+      className={clsx(
+        albert.variable,
+        jetBrainsMono.variable,
+        resumeConfig.appTheme === ThemeSetting.Dark && 'dark',
+      )}
+    >
       <body className="bg-neutral-1 text-neutral-12 selection:bg-accent-11 selection:text-neutral-1">
         {children}
       </body>

--- a/src/components/PDF/Icons/BuildingColumns.tsx
+++ b/src/components/PDF/Icons/BuildingColumns.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const BuildingColumns: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/Calendar.tsx
+++ b/src/components/PDF/Icons/Calendar.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const Calendar: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/CircleBriefcase.tsx
+++ b/src/components/PDF/Icons/CircleBriefcase.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const CircleBriefcase: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/CircleCheck.tsx
+++ b/src/components/PDF/Icons/CircleCheck.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const CircleCheck: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/CircleGraduationCap.tsx
+++ b/src/components/PDF/Icons/CircleGraduationCap.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const CircleGraduationCap: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/CircleIdCard.tsx
+++ b/src/components/PDF/Icons/CircleIdCard.tsx
@@ -1,10 +1,10 @@
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
-import * as colors from '@radix-ui/colors';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const CircleIdCard: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/CirclePaintbrush.tsx
+++ b/src/components/PDF/Icons/CirclePaintbrush.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const CirclePaintbrush: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/CircleUser.tsx
+++ b/src/components/PDF/Icons/CircleUser.tsx
@@ -1,10 +1,10 @@
-import * as colors from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
 import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getNeutralColor } from '../../../helpers/colors';
 
-const neutralColor =
-  colors[resumeConfig.neutralColor][`${resumeConfig.neutralColor}12`];
+const theme = resumeConfig.pdfTheme;
+const neutralColor = getNeutralColor(12, theme);
 
 export const CircleUser: React.FC<PdfIconProps> = ({ size }) => {
   return (

--- a/src/components/PDF/Icons/Star.tsx
+++ b/src/components/PDF/Icons/Star.tsx
@@ -1,12 +1,19 @@
-import { amber } from '@radix-ui/colors';
+import { amberDark } from '@radix-ui/colors';
 import { Path, Svg } from '@react-pdf/renderer';
 import React from 'react';
+import { Theme } from '../../../../edit-me/config/Config';
+import resumeConfig from '../../../../edit-me/config/resumeConfig';
+import { getAccentColor } from '../../../helpers/colors';
+
+const theme = resumeConfig.pdfTheme;
 
 export const Star: React.FC<PdfIconProps> = ({ size }) => {
   return (
     <Svg style={{ height: size, width: size }} viewBox="0 0 512 512">
       <Path
-        fill={amber.amber9}
+        fill={
+          theme === Theme.Dark ? amberDark.amber11 : getAccentColor(11, theme)
+        }
         d="M316.9 18C311.6 7 300.4 0 288.1 0s-23.4 7-28.8 18L195 150.3 51.4 171.5c-12 1.8-22 10.2-25.7 21.7s-.7 24.2 7.9 32.7L137.8 329 113.2 474.7c-2 12 3 24.2 12.9 31.3s23 8 33.8 2.3l128.3-68.5 128.3 68.5c10.8 5.7 23.9 4.9 33.8-2.3s14.9-19.3 12.9-31.3L438.5 329 542.7 225.9c8.6-8.5 11.7-21.2 7.9-32.7s-13.7-19.9-25.7-21.7L381.2 150.3 316.9 18z"
       />
     </Svg>

--- a/src/components/PDF/PDF.tsx
+++ b/src/components/PDF/PDF.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/alt-text */
-import * as colors from '@radix-ui/colors';
 import {
   Document,
   Font,
@@ -14,6 +13,7 @@ import { HtmlProps } from 'react-pdf-html/dist/Html';
 import resumeConfig from '../../../edit-me/config/resumeConfig';
 import { CMSData } from '../../cms-integration/getCMSIntegration';
 import { contrastColor } from '../../helpers/colorContrast';
+import { getAccentColor, getNeutralColor } from '../../helpers/colors';
 import { getFullName } from '../../helpers/utils';
 import { BuildingColumns } from './Icons/BuildingColumns';
 import { Calendar } from './Icons/Calendar';
@@ -25,12 +25,9 @@ import { CirclePaintbrush } from './Icons/CirclePaintbrush';
 import { CircleUser } from './Icons/CircleUser';
 import { Star } from './Icons/Star';
 import { htmlRenderers } from './htmlRenderers';
+import { Theme } from '../../../edit-me/config/Config';
 
-const configAccent = resumeConfig.accentColor;
-const configNeutral = resumeConfig.neutralColor;
-const accentColor = colors[configAccent];
-const neutralColor = colors[configNeutral];
-
+const theme = resumeConfig.pdfTheme;
 const domain = process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
   : 'http://localhost:3000';
@@ -106,7 +103,8 @@ const spacers = {
 const styles = StyleSheet.create({
   page: {
     alignItems: 'stretch',
-    backgroundColor: neutralColor[`${configNeutral}1`],
+    backgroundColor: getNeutralColor(1, theme),
+    color: getNeutralColor(12, theme),
     display: 'flex',
     flexDirection: 'row',
     flexWrap: 'nowrap',
@@ -117,9 +115,9 @@ const styles = StyleSheet.create({
   },
   sidebar: {
     alignSelf: 'stretch',
-    backgroundColor: neutralColor[`${configNeutral}3`],
+    backgroundColor: getNeutralColor(3, theme),
     display: 'flex',
-    color: neutralColor[`${configNeutral}12`],
+    color: getNeutralColor(12, theme),
     flexBasis: '30%',
     flexDirection: 'column',
     flexGrow: 0,
@@ -127,7 +125,10 @@ const styles = StyleSheet.create({
   },
   sidebarContent: { padding: spacers[4] },
   header: {
-    backgroundColor: accentColor[`${configAccent}9`],
+    backgroundColor:
+      theme === Theme.Dark
+        ? getNeutralColor(2, theme)
+        : getAccentColor(9, theme),
     color: contrastColor,
     padding: `${spacers[6]} ${spacers[4]}`,
     textAlign: 'center',
@@ -197,9 +198,9 @@ const styles = StyleSheet.create({
     fontStyle: 'italic',
   },
   professionalTitle: {
-    backgroundColor: neutralColor[`${configNeutral}12`],
+    backgroundColor: getNeutralColor(12, theme),
     borderRadius: '3px',
-    color: neutralColor[`${configNeutral}1`],
+    color: getNeutralColor(1, theme),
     fontWeight: 700,
     paddingHorizontal: spacers[1],
   },
@@ -212,14 +213,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   a: {
-    color: accentColor[`${configAccent}11`],
+    color: getAccentColor(11, theme),
     textDecoration: 'underline',
   },
   list: {
     marginTop: spacers[2],
   },
   code: {
-    backgroundColor: neutralColor[`${configNeutral}4`],
+    backgroundColor: getNeutralColor(4, theme),
     borderRadius: '3px',
     fontFamily: 'JetBrains Mono',
     fontWeight: 500,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import * as colors from '@radix-ui/colors';
 import type { Config } from 'tailwindcss';
 import windyRadixPlugin from 'windy-radix-palette';
 import { toRadixVars } from 'windy-radix-palette/vars';
+import { ThemeSetting } from './edit-me/config/Config';
 import resumeConfig from './edit-me/config/resumeConfig';
 import { contrastColor } from './src/helpers/colorContrast';
 
@@ -10,6 +11,7 @@ export default {
     './src/app/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',
   ],
+  darkMode: resumeConfig.appTheme === ThemeSetting.System ? 'media' : 'class',
   plugins: [
     windyRadixPlugin({
       // only generate CSS vars for configured color choices


### PR DESCRIPTION
## [3.5.0] - 2023-04-07

### Added

- `resumeConfig.appTheme` property
  - If set to `ThemeSetting.System`, Tailwind will use `media` mode to set the color theme
  - If set to `ThemeSetting.Light` or `ThemeSetting.Dark`, Tailwind will use the `class` mode to set the color scheme
  - The app layout applies the `dark` class if `resumeConfig.appTheme` is set to `ThemeSetting.Dark`
- `resumeConfig.pdfTheme` property
  - Will set the color theme only for a generated PDF
  - Can be set independently of the app theme
  - Defaults to `Theme.Light` for printing purposes

### Changed

- All PDF icons use the color helper functions